### PR TITLE
MD-2818: Loading serialized scene with character info

### DIFF
--- a/libraries/animation/src/DeepMotionNode.h
+++ b/libraries/animation/src/DeepMotionNode.h
@@ -4,15 +4,20 @@
 #include "deepMotion_interface.h"
 
 #include "AnimNode.h"
+#include "qnetworkreply.h"
 
 class RotationConstraint;
+class Resource;
 
-class DeepMotionNode : public AnimNode {
+namespace avatar
+{
+    struct SimpleGenericHandle;
+} // avatar
+
+class DeepMotionNode : public AnimNode, public QObject {
 public:
     DeepMotionNode() = delete;
-    explicit DeepMotionNode(const QString& id) : AnimNode(AnimNode::Type::InverseKinematics, id) {
-        InitializeIntegration();
-    }
+    explicit DeepMotionNode(const QString& id);
     DeepMotionNode(const DeepMotionNode&) = delete;
     DeepMotionNode(const DeepMotionNode&&) = delete;
     DeepMotionNode operator=(const DeepMotionNode&) = delete;
@@ -29,6 +34,9 @@ public:
         LimitCenterPoses,
         NumSolutionSources,
     };
+
+    void characterLoaded(const QByteArray data);
+    void characterFailedToLoad(QNetworkReply::NetworkError error);
 
     void loadPoses(const AnimPoseVec& poses);
 
@@ -49,6 +57,9 @@ protected:
 
     const SolutionSource _solutionSource{ SolutionSource::PreviousSolution };
     QString _solutionSourceVar;
+
+    avatar::SimpleGenericHandle _sceneHandle;
+    QSharedPointer<Resource> _characterResource;
 };
 
 #endif // hifi_DeepMotionNode_h

--- a/libraries/deep-motion/src/deepMotion_interface.h
+++ b/libraries/deep-motion/src/deepMotion_interface.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "dm_public/types.h"
+
 #ifdef __cplusplus
     extern "C" {
 #endif
@@ -15,6 +17,7 @@
 #endif
 
 AVATAR_DLL void InitializeIntegration();
+AVATAR_DLL avatar::SimpleGenericHandle LoadCharacterOnScene(const uint8_t* rawData);
 AVATAR_DLL void FinalizeIntegration();
 AVATAR_DLL void TickIntegration(float deltaTime);
 

--- a/libraries/deep-motion/src/dm_public/assets.h
+++ b/libraries/deep-motion/src/dm_public/assets.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <string>
+#include "dm_public/guid.h"
+
+namespace avatar
+{
+    enum class AssetType : uint8_t
+    {
+        GENERIC_ASSET,
+        CHARACTER_ASSET,
+        ANIMATION_ASSET,
+        MAP_ASSET,
+        CONTROL_PARAMS,
+		FRAGMENT_HOST
+    };
+
+    struct AssetDescriptor
+    {
+        AssetType m_AssetType;
+        Guid m_AssetID;
+        std::string m_SuggestedFileName;
+        std::string m_SuggestedFolder;
+    };
+}

--- a/libraries/deep-motion/src/dm_public/commands/asset_commands.h
+++ b/libraries/deep-motion/src/dm_public/commands/asset_commands.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "dm_public/assets.h"
+#include "dm_public/guid.h"
+#include "dm_public/i_array_interface.h"
+
+namespace avatar
+{    
+    struct AssetCommands
+    {
+        typedef bool(*AssetQueryAvailableFn)();
+        AssetQueryAvailableFn m_AssetQueryAvailableFn;
+        typedef bool(*SaveAssetFn)(const AssetDescriptor& assetDescriptor, const uint8_t* data, uint32_t numBytes);
+        SaveAssetFn m_SaveAssetFn;
+        typedef bool(*LoadAssetFn)(const Guid& assetID, uint8_t* const& dataOut, uint32_t& numBytesOut);
+        LoadAssetFn m_LoadAssetFn;
+        typedef bool(*QueryAssetFn)(AssetType, IArrayInterface<AssetDescriptor>& assetsOut);
+        QueryAssetFn m_QueryAssetFn;
+    };
+}

--- a/libraries/deep-motion/src/dm_public/commands/core_commands.h
+++ b/libraries/deep-motion/src/dm_public/commands/core_commands.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <cstdio>
+
+namespace avatar
+{
+
+struct CoreCommands
+{
+	typedef void*(*AllocateFn)(size_t);
+	AllocateFn m_AllocateFn;
+	typedef void(*FreeFn)(void*);
+	FreeFn m_FreeFn;
+};
+
+}

--- a/libraries/deep-motion/src/dm_public/guid.h
+++ b/libraries/deep-motion/src/dm_public/guid.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <array>
+#include <stdint.h>
+
+namespace avatar
+{
+
+class Guid
+{
+  public:
+    static Guid CreateNewGuid();
+    Guid();
+    bool isEmpty() const;
+    std::array<uint8_t, 16> m_Data;
+};
+}

--- a/libraries/deep-motion/src/dm_public/i_array_interface.h
+++ b/libraries/deep-motion/src/dm_public/i_array_interface.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <stdint.h>
+
+namespace avatar
+{
+	
+template<typename T>
+class IArrayInterface
+{
+public:
+	virtual size_t Size() const = 0;
+	virtual void Reserve(size_t size) = 0;
+	virtual void PushBack(const T& value) = 0;
+	virtual void PushBack(T&& value) = 0;
+	virtual const T& operator[](size_t index) const = 0;
+	virtual T& operator[](size_t index) = 0;
+	virtual void Resize(size_t newSize) = 0;
+    virtual T& Grow() = 0;
+};
+
+}

--- a/libraries/deep-motion/src/dm_public/interfaces/i_engine_interface.h
+++ b/libraries/deep-motion/src/dm_public/interfaces/i_engine_interface.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "dm_public/types.h"
+
+namespace avatar
+{
+struct CoreCommands;
+struct AssetCommands;
+
+class IEngineInterface
+{
+public:
+	IEngineInterface() {}
+	virtual void InitializeRuntime() = 0;
+	virtual void FinalizeRuntime() = 0;
+	virtual void RegisterCoreCommands(CoreCommands& commandStruct) = 0;
+    virtual void RegisterAssetCommands(AssetCommands& assetCommands) = 0;
+	virtual void TickGeneralPurposeRuntime(float detlaTime) = 0;
+
+    virtual SceneHandle DeserializeAndLoadScene(const uint8_t* rawBuffer) = 0;
+    virtual RigidBodyHandle GetRigidBodyByName(const char* name) = 0;
+    virtual bool GetRigidBodyTransform(RigidBodyHandle rbHandle, Float3* pos, Float4* ori) = 0;
+
+	virtual ~IEngineInterface() {}
+private:
+	IEngineInterface(const IEngineInterface&) = delete;
+	IEngineInterface& operator=(const IEngineInterface&) = delete;
+};
+
+extern IEngineInterface& GetAvatarEngineInterfaceController();
+
+}

--- a/libraries/deep-motion/src/dm_public/opaque_handle.h
+++ b/libraries/deep-motion/src/dm_public/opaque_handle.h
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace avatar
+{
+
+template<typename UnderlyingType, uint32_t UNIQUE_ID>
+class OpaqueHandle
+{
+public:
+	explicit OpaqueHandle(UnderlyingType val) : m_Val(val) {}
+	explicit operator UnderlyingType() const { return m_Val; }
+	
+	bool operator==(const OpaqueHandle& other) const { return m_Val == other.m_Val; }
+	bool operator!=(const OpaqueHandle& other) const { return m_Val != other.m_Val; }
+private:
+	UnderlyingType m_Val;
+};
+
+}

--- a/libraries/deep-motion/src/dm_public/types.h
+++ b/libraries/deep-motion/src/dm_public/types.h
@@ -1,0 +1,47 @@
+#pragma once
+#include <stdint.h>
+#include "opaque_handle.h"
+#include "guid.h"
+
+namespace avatar
+{	
+namespace Detail
+{
+enum HandleTypes
+{
+    INVALID_HANDLE,
+	ANIMATION_HANDLE,
+	DISPLACEMENT_HANDLE,
+    SCENE_HANDLE,
+    RIGIDBODY_HANDLE
+};
+
+enum ResourceIdentifierTypes
+{
+	ANIM_RESOURCE
+};
+}
+
+using AnimHandle = OpaqueHandle<void*, Detail::ANIMATION_HANDLE>;
+using AnimResId = OpaqueHandle<Guid, Detail::ANIM_RESOURCE>;
+using DisplacementHandle = OpaqueHandle<void*, Detail::DISPLACEMENT_HANDLE>;
+using SceneHandle = OpaqueHandle<void*, Detail::SCENE_HANDLE>;
+using RigidBodyHandle = OpaqueHandle<void*, Detail::RIGIDBODY_HANDLE>;
+
+struct SimpleGenericHandle
+{
+    void* m_rawHandle = nullptr;
+    Detail::HandleTypes m_type = Detail::INVALID_HANDLE;
+};
+
+struct Float3
+{
+    float m[3];
+};
+
+struct Float4
+{
+    float m[4];
+};
+
+}


### PR DESCRIPTION
+ with fallback to loading from hardcoded path (due to errors while loading from resources)
+ storing handle to deserialized object

Loading from resources fails because `PathUtils::resourcesUrl("deepMotion/schoolBoyScene.json");` returns `"qrc:///deepMotion/schoolBoyScene.json"`, instead of `"file:///deepMotion/schoolBoyScene.json"` and resource fails to find a file `schoolBoyScene.json` located in `HighFidelity\interface\resources\deepMotion`